### PR TITLE
remove check branch name in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,7 +64,6 @@ pipeline:
     auto_tag: true
     dockerfile: Dockerfile
     when:
-      branch: master
       event: [ push, tag ]
 
   publish_linux_i386:
@@ -77,7 +76,6 @@ pipeline:
     auto_tag_suffix: i386
     dockerfile: Dockerfile.i386
     when:
-      branch: master
       event: [ push, tag ]
 
   publish_linux_arm64:
@@ -90,7 +88,6 @@ pipeline:
     auto_tag_suffix: arm64
     dockerfile: Dockerfile.arm64
     when:
-      branch: master
       event: [ push, tag ]
 
   publish_linux_arm:
@@ -103,7 +100,6 @@ pipeline:
     auto_tag_suffix: arm
     dockerfile: Dockerfile.arm
     when:
-      branch: master
       event: [ push, tag ]
 
   microbadger:


### PR DESCRIPTION
`plugins/docker` will ignore build if commit branch is not equal to default branch for the latest tag.

ref: https://github.com/drone-plugins/drone-docker/pull/160

cc @tboerger 